### PR TITLE
Move example sketch to appropriately named folder

### DIFF
--- a/examples/Test/Test.ino
+++ b/examples/Test/Test.ino
@@ -1,6 +1,6 @@
 /*
  Name:		Test.ino
- Author:	Sindre Halbjørhus
+ Author:	Sindre HalbjÃ¸rhus
 */
 
 #define DEBUG


### PR DESCRIPTION
The Arduino IDE requires the sketch folder name to match the filename of the primary sketch file. This change causes the example sketch to be accessible via the Arduino IDE's File > Examples > LIBRARYNAME menu after the library is installed.